### PR TITLE
Fix Markdown Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#raml-tutorial-200
+# raml-tutorial-200
 
 Step by step 200 raml tutorial code


### PR DESCRIPTION
Github doesn't render headers that lack a space between the `#` and the header itself anymore.

This commit fixes the problem.